### PR TITLE
8 roc curve

### DIFF
--- a/complete_confusion/evaluate.py
+++ b/complete_confusion/evaluate.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 from pathlib import Path
 from typing import Union, Collection, Optional
@@ -43,7 +44,7 @@ def _calculate_performance_metrics(truths: Collection[int],
     if probabilities is not None:
         from sklearn.metrics import roc_auc_score, roc_curve
         fpr, tpr, thresholds = roc_curve(y_true=truth_labels, y_score=probabilities, pos_label=(list(classes)[0]))
-        roc = df({'fpr': fpr, 'tpr': tpr})
+        roc = df({'fpr': fpr, 'tpr': tpr, 'threshold': thresholds})
         roc_auc = (roc_auc_score(truth_labels, probabilities))
     else:
         roc = None
@@ -130,8 +131,10 @@ def _table_df_to_str(metrics_df, variable_name):
         {"type": idx, **{col: float(metrics_df.loc[idx, col]) for col in metrics_df.columns}}
         for idx in metrics_df.index
     ]
+
+    metrics_values_str = json.dumps(metrics_values)
     return ("const " + variable_name + " = {\n    values: " +
-            str(metrics_values).replace("'", '"') + "\n};\n")
+            metrics_values_str + "\n};\n")
 
 
 def _encode(e:str)->str:

--- a/complete_confusion/evaluate.py
+++ b/complete_confusion/evaluate.py
@@ -112,7 +112,7 @@ def save_performance_metrics_to_html(
                                                                                 classes)
 
     class_metrics_js_str = _table_df_to_str(class_metrics_df, "classMetricsData")
-    roc_js_str = "" if roc_df is None else _table_df_to_str(roc_df, "rocData")
+    roc_js_str = "" if roc_df is None else _table_df_to_str(roc_df, "rocCurveData")
     general_metrics_js_str = _table_df_to_str(general_metrics_df, "generalMetricsData")
 
     # Save the data to a JavaScript file
@@ -162,7 +162,7 @@ def _create_confusion_matrix_js_str(
     if probabilities is not None:
         headers.append('confidence_score')
         columns.append(probabilities)
-    data_csv_str = '\n'.join([','.join([str(_encode(e)) for e in data_point]) for data_point in zip(*columns)])
+    data_csv_str = '\n'.join([','.join([str(_encode(str(e))) for e in data_point]) for data_point in zip(*columns)])
     confusion_matrix_js_str = "const confusionMatrixData = `\n" + ','.join(headers) + "\n" + data_csv_str + "`;\n"
 
     return confusion_matrix_js_str

--- a/complete_confusion/evaluate.py
+++ b/complete_confusion/evaluate.py
@@ -29,7 +29,7 @@ def _calculate_performance_metrics(truths: Collection[int],
     :param predictions: list of model predictions
     :param probabilities: list of model predicted probabilities
     :param classes: the collection of all possible labels
-    :return: a dataframe with class level metrics and a dataframe with general metrics and a one with ROC values
+    :return: 4 dataframes containing class level metrics, general metrics, ROC values and the confusion matrix
     """
     truth_labels = [list(classes)[i] for i in truths]
     prediction_labels = [list(classes)[i] for i in predictions]
@@ -108,14 +108,16 @@ def save_performance_metrics_to_html(
     confusion_matrix_js_str = _create_confusion_matrix_js_str(
         predictions, truths, probabilities, classes, text_representations, image_representations)
 
-    class_metrics_df, general_metrics_df, _, _ = _calculate_performance_metrics(truths, predictions, probabilities,
+    class_metrics_df, general_metrics_df, roc_df, _ = _calculate_performance_metrics(truths, predictions, probabilities,
                                                                                 classes)
+
     class_metrics_js_str = _table_df_to_str(class_metrics_df, "classMetricsData")
+    roc_js_str = "" if roc_df is None else _table_df_to_str(roc_df, "rocData")
     general_metrics_js_str = _table_df_to_str(general_metrics_df, "generalMetricsData")
 
     # Save the data to a JavaScript file
     with open(output_path / 'complete-confusion-data.js', 'w', encoding='utf-8') as f:
-        f.write('\n'.join([confusion_matrix_js_str, class_metrics_js_str, general_metrics_js_str]))
+        f.write('\n'.join([confusion_matrix_js_str, class_metrics_js_str, general_metrics_js_str, roc_js_str]))
 
     shutil.copy(resources / 'complete-confusion.html', output_path)
     shutil.copy(resources / 'complete-confusion.css', output_path)

--- a/complete_confusion/resources/complete-confusion.html
+++ b/complete_confusion/resources/complete-confusion.html
@@ -35,6 +35,10 @@
     <div>
         <div id="class-metrics" class="view"></div>
     </div>
+
+    <h1>ROC curve</h1>
+    <div id="roc-curve" class="view"></div>
+
     <script>
         // Function to parse CSV string into an array of objects
         function parseCSV(csvContent) {

--- a/complete_confusion/resources/complete-confusion.html
+++ b/complete_confusion/resources/complete-confusion.html
@@ -114,26 +114,32 @@
         // Render class metrics chart
         vegaEmbed('#general-metrics', generalMetricsSpec);
 
-        // Render ROC curve chart
-        vegaEmbed('#roc-curve', rocCurveSpec).then(result => {
-            console.log('ROC chart embedded successfully');
-            const vegaContainer = result.view.container();
-            console.log('Container:', vegaContainer);
+        // Render ROC curve chart (optionally)
+        if (rocCurveSpec !== null) {
+            // Render ROC curve chart
+            vegaEmbed('#roc-curve', rocCurveSpec).then(result => {
+                console.log('ROC chart embedded successfully');
+                const vegaContainer = result.view.container();
+                console.log('Container:', vegaContainer);
 
-            vegaContainer.addEventListener('mouseover', (e) => {
-                console.log('Mouseover event fired', e.target);
-                result.view.signal('hideSymbols', false);
-                result.view.run();
-                console.log('Signal set to true');
-            });
+                vegaContainer.addEventListener('mouseover', (e) => {
+                    console.log('Mouseover event fired', e.target);
+                    result.view.signal('hideSymbols', false);
+                    result.view.run();
+                    console.log('Signal set to true');
+                });
 
-            vegaContainer.addEventListener('mouseout', (e) => {
-                console.log('Mouseout event fired', e.target);
-                result.view.signal('hideSymbols', true);
-                result.view.run();
-                console.log('Signal set to false');
-            });
-        }).catch(console.error);
+                vegaContainer.addEventListener('mouseout', (e) => {
+                    console.log('Mouseout event fired', e.target);
+                    result.view.signal('hideSymbols', true);
+                    result.view.run();
+                    console.log('Signal set to false');
+                });
+            }).catch(console.error);
+        }
+        else{
+            document.getElementById('roc-curve').innerHTML = '<p>No ROC curve data available.</p>';
+        }
     </script>
   </section>
   </div>

--- a/complete_confusion/resources/complete-confusion.html
+++ b/complete_confusion/resources/complete-confusion.html
@@ -115,7 +115,25 @@
         vegaEmbed('#general-metrics', generalMetricsSpec);
 
         // Render ROC curve chart
-        vegaEmbed('#roc-curve', rocCurveSpec);
+        vegaEmbed('#roc-curve', rocCurveSpec).then(result => {
+            console.log('ROC chart embedded successfully');
+            const vegaContainer = result.view.container();
+            console.log('Container:', vegaContainer);
+
+            vegaContainer.addEventListener('mouseover', (e) => {
+                console.log('Mouseover event fired', e.target);
+                result.view.signal('hideSymbols', false);
+                result.view.run();
+                console.log('Signal set to true');
+            });
+
+            vegaContainer.addEventListener('mouseout', (e) => {
+                console.log('Mouseout event fired', e.target);
+                result.view.signal('hideSymbols', true);
+                result.view.run();
+                console.log('Signal set to false');
+            });
+        }).catch(console.error);
     </script>
   </section>
   </div>

--- a/complete_confusion/resources/complete-confusion.html
+++ b/complete_confusion/resources/complete-confusion.html
@@ -113,6 +113,9 @@
 
         // Render class metrics chart
         vegaEmbed('#general-metrics', generalMetricsSpec);
+
+        // Render ROC curve chart
+        vegaEmbed('#roc-curve', rocCurveSpec);
     </script>
   </section>
   </div>

--- a/complete_confusion/resources/complete-confusion.js
+++ b/complete_confusion/resources/complete-confusion.js
@@ -283,7 +283,10 @@ const rocCurveSpec = {
           "stroke": {"value": "steelblue"},
           "strokeWidth": {"value": 1.5},
           "fill": {"value": "white"},
-          "size": {"value": 30}
+          "size": {"value": 30},
+          "tooltip": {
+            "signal": "{'Threshold': format(datum.threshold, '.8f'), 'FPR': format(datum.fpr, '.2f'), 'TPR': format(datum.tpr, '.2f')}"
+          }
         }
       }
     }

--- a/complete_confusion/resources/complete-confusion.js
+++ b/complete_confusion/resources/complete-confusion.js
@@ -193,3 +193,99 @@ const generalMetricsSpec = {
     }
   }
 };
+
+const rocCurveSpec = {
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "description": "ROC Curve",
+  "width": 500,
+  "height": 500,
+  "padding": 5,
+  "config": {
+    "title": {
+      "fontSize": 16
+    }
+  },
+
+  "title": {
+    "text": {"signal": "'ROC Curve'"},
+  },
+
+  "data": [
+    {
+      "name": "table",
+      "values": rocCurveData["values"],
+      "transform": [
+        {
+          "type": "extent",
+          "field": "fpr",
+          "signal": "fprs"
+        }
+      ]
+    },
+  ],
+
+  "scales": [
+    {
+      "name": "x",
+      "type": "linear",
+      "range": "width",
+      "nice": true,
+      "zero": false,
+      "domain": {"data": "table", "field": "fpr"}
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "range": "height",
+      "nice": true,
+      "zero": true,
+      "domain": {"data": "table", "field": "tpr"}
+    },
+  ],
+
+  "axes": [
+    {
+      "orient": "left",
+      "scale": "y",
+      "title": "True Positive Rate",
+      "titlePadding": 10,
+      "grid": true
+    },
+    {
+      "orient": "bottom",
+      "scale": "x",
+      "title": "False Positive Rate",
+      "tickCount": 10
+    }
+  ],
+
+  "marks": [
+    {
+      "type": "line",
+      "from": {"data": "table"},
+      "encode": {
+        "enter": {
+          "interpolate": {"value": "monotone"},
+          "x": {"scale": "x", "field": "fpr"},
+          "y": {"scale": "y", "field": "tpr"},
+          "stroke": {"value": "steelblue"},
+          "strokeWidth": {"value": 3}
+        }
+      }
+    },
+    {
+      "type": "symbol",
+      "from": {"data": "table"},
+      "encode": {
+        "enter": {
+          "x": {"scale": "x", "field": "fpr"},
+          "y": {"scale": "y", "field": "tpr"},
+          "stroke": {"value": "steelblue"},
+          "strokeWidth": {"value": 1.5},
+          "fill": {"value": "white"},
+          "size": {"value": 30}
+        }
+      }
+    }
+  ],
+}

--- a/complete_confusion/resources/complete-confusion.js
+++ b/complete_confusion/resources/complete-confusion.js
@@ -194,111 +194,120 @@ const generalMetricsSpec = {
   }
 };
 
-const rocCurveSpec = {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
-  "description": "ROC Curve",
-  "width": 500,
-  "height": 500,
-  "padding": 5,
-  "config": {
+let rocCurveSpec = null;
+
+if (typeof rocCurveData !== 'undefined') {
+  const aucItem = generalMetricsData.values.find(item => item.type === 'auc');
+  const rocTitleText = aucItem ?
+      `ROC Curve (AUC = ${aucItem.score.toFixed(3)})` :
+      'ROC Curve';
+
+  rocCurveSpec = {
+    "$schema": "https://vega.github.io/schema/vega/v5.json",
+    "description": "ROC Curve",
+    "width": 500,
+    "height": 500,
+    "padding": 5,
+    "config": {
+      "title": {
+        "fontSize": 16
+      }
+    },
+
     "title": {
-      "fontSize": 16
-    }
-  },
-
-  "title": {
-    "text": {"signal": "'ROC Curve'"},
-  },
-
-  "signals": [
-    {
-      "name": "hideSymbols",
-      "value": true
-    }
-  ],
-
-  "data": [
-    {
-      "name": "table",
-      "values": rocCurveData["values"],
-      "transform": [
-        {
-          "type": "extent",
-          "field": "fpr",
-          "signal": "fprs"
-        }
-      ]
+      "text": rocTitleText
     },
-  ],
 
-  "scales": [
-    {
-      "name": "x",
-      "type": "linear",
-      "range": "width",
-      "nice": true,
-      "zero": false,
-      "domain": {"data": "table", "field": "fpr"}
-    },
-    {
-      "name": "y",
-      "type": "linear",
-      "range": "height",
-      "nice": true,
-      "zero": true,
-      "domain": {"data": "table", "field": "tpr"}
-    },
-  ],
-
-  "axes": [
-    {
-      "orient": "left",
-      "scale": "y",
-      "title": "True Positive Rate",
-      "titlePadding": 10,
-      "grid": true
-    },
-    {
-      "orient": "bottom",
-      "scale": "x",
-      "title": "False Positive Rate",
-      "tickCount": 10
-    }
-  ],
-
-  "marks": [
-    {
-      "type": "line",
-      "from": {"data": "table"},
-      "encode": {
-        "enter": {
-          "interpolate": {"value": "monotone"},
-          "x": {"scale": "x", "field": "fpr"},
-          "y": {"scale": "y", "field": "tpr"},
-          "stroke": {"value": "steelblue"},
-          "strokeWidth": {"value": 3}
-        }
+    "signals": [
+      {
+        "name": "hideSymbols",
+        "value": true
       }
-    },
-    {
-      "type": "symbol",
-      "from": {"data": "table"},
-      "encode": {
-        "enter": {
-          "x": {"scale": "x", "field": "fpr"},
-          "y": {"scale": "y", "field": "tpr"},
-          "stroke": {"value": "steelblue"},
-          "strokeWidth": {"value": 1.5},
-          "fill": {"value": "white"},
-          "size": {"value": 30},
-          "tooltip": {
-            "signal": "{'Threshold': format(datum.threshold, '.8f'), 'FPR': format(datum.fpr, '.2f'), 'TPR': format(datum.tpr, '.2f')}"
+    ],
+
+    "data": [
+      {
+        "name": "table",
+        "values": rocCurveData["values"],
+        "transform": [
+          {
+            "type": "extent",
+            "field": "fpr",
+            "signal": "fprs"
           }
-        },
-        "update": {
-          "opacity": {"signal": "hideSymbols ? 0 : 1"}
+        ]
+      },
+    ],
+
+    "scales": [
+      {
+        "name": "x",
+        "type": "linear",
+        "range": "width",
+        "nice": true,
+        "zero": false,
+        "domain": {"data": "table", "field": "fpr"}
+      },
+      {
+        "name": "y",
+        "type": "linear",
+        "range": "height",
+        "nice": true,
+        "zero": true,
+        "domain": {"data": "table", "field": "tpr"}
+      },
+    ],
+
+    "axes": [
+      {
+        "orient": "left",
+        "scale": "y",
+        "title": "True Positive Rate",
+        "titlePadding": 10,
+        "grid": true
+      },
+      {
+        "orient": "bottom",
+        "scale": "x",
+        "title": "False Positive Rate",
+        "tickCount": 10
+      }
+    ],
+
+    "marks": [
+      {
+        "type": "line",
+        "from": {"data": "table"},
+        "encode": {
+          "enter": {
+            "interpolate": {"value": "monotone"},
+            "x": {"scale": "x", "field": "fpr"},
+            "y": {"scale": "y", "field": "tpr"},
+            "stroke": {"value": "steelblue"},
+            "strokeWidth": {"value": 3}
+          }
+        }
+      },
+      {
+        "type": "symbol",
+        "from": {"data": "table"},
+        "encode": {
+          "enter": {
+            "x": {"scale": "x", "field": "fpr"},
+            "y": {"scale": "y", "field": "tpr"},
+            "stroke": {"value": "steelblue"},
+            "strokeWidth": {"value": 1.5},
+            "fill": {"value": "white"},
+            "size": {"value": 30},
+            "tooltip": {
+              "signal": "{'Threshold': format(datum.threshold, '.8f'), 'FPR': format(datum.fpr, '.2f'), 'TPR': format(datum.tpr, '.2f')}"
+            }
+          },
+          "update": {
+            "opacity": {"signal": "hideSymbols ? 0 : 1"}
+          }
         }
       }
-    }
-  ],
+    ],
+  }
 }

--- a/complete_confusion/resources/complete-confusion.js
+++ b/complete_confusion/resources/complete-confusion.js
@@ -210,6 +210,13 @@ const rocCurveSpec = {
     "text": {"signal": "'ROC Curve'"},
   },
 
+  "signals": [
+    {
+      "name": "hideSymbols",
+      "value": true
+    }
+  ],
+
   "data": [
     {
       "name": "table",
@@ -287,6 +294,9 @@ const rocCurveSpec = {
           "tooltip": {
             "signal": "{'Threshold': format(datum.threshold, '.8f'), 'FPR': format(datum.fpr, '.2f'), 'TPR': format(datum.tpr, '.2f')}"
           }
+        },
+        "update": {
+          "opacity": {"signal": "hideSymbols ? 0 : 1"}
         }
       }
     }

--- a/tests/performance_metrics_test_data.py
+++ b/tests/performance_metrics_test_data.py
@@ -47,12 +47,12 @@ def get_eulaw_test_data() -> PerformanceMetricsTestData:
     predictions = df["prediction"].tolist()
     trues = df["true"].tolist()
     class_list = ["regulatory", "non-regulatory"]
-
+    probabilities = df["prob_0"].tolist()
     return PerformanceMetricsTestData(
         name="eulaw",
         predictions=predictions,
         truths=trues,
-        probabilities=None,
+        probabilities=probabilities,
         class_list=class_list,
         text_representations=df["sentence"].tolist(),
     )

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -31,7 +31,8 @@ def test_evaluate_file_created(tmpdir, test_case, expected_output_file):
     save_performance_metrics_to_html(test_case.predictions, test_case.truths, classes=test_case.class_list,
                                      text_representations=test_case.text_representations,
                                      image_representations=test_case.image_representations,
+                                     output_path=tmpdir,
                                      probabilities=test_case.probabilities,
-                                     output_path=tmpdir)
+                                     )
 
     assert expected_output_path.exists(), "Performance metrics HTML file was not created."

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -31,6 +31,7 @@ def test_evaluate_file_created(tmpdir, test_case, expected_output_file):
     save_performance_metrics_to_html(test_case.predictions, test_case.truths, classes=test_case.class_list,
                                      text_representations=test_case.text_representations,
                                      image_representations=test_case.image_representations,
+                                     probabilities=test_case.probabilities,
                                      output_path=tmpdir)
 
     assert expected_output_path.exists(), "Performance metrics HTML file was not created."


### PR DESCRIPTION
Adds an ROC curve to the outputs.  
<img width="1098" height="1091" alt="image" src="https://github.com/user-attachments/assets/dda660ee-3e08-4162-b9b5-f9c1ba6cd1c0" />
Marks on each point in the curve should show up as circles when mouse over the canvas and should be hidden otherwise, just showing the line.
<img width="873" height="1008" alt="image" src="https://github.com/user-attachments/assets/f5247535-7ab8-48d8-8b49-61032f331d1a" />
When the mouse is over one of the circular marks, a tooltip should show the related decision boundary.
<img width="949" height="1009" alt="image" src="https://github.com/user-attachments/assets/37c1b548-e9f7-4d0f-9309-0a6242c0555a" />

The ROC chart should only be shown if we are dealing with a binary classifier.
<img width="990" height="609" alt="image" src="https://github.com/user-attachments/assets/93818e4c-5e64-49d8-8c24-ad0e95530a4e" />